### PR TITLE
Fix win32 garbled Unicode characters

### DIFF
--- a/src/resultview/customview.ts
+++ b/src/resultview/customview.ts
@@ -62,7 +62,7 @@ export class CustomView extends EventEmitter implements Disposable {
         let options = {
             enableScripts: true,
             retainContextWhenHidden: false, // we dont need to keep the state
-            localResourceRoots: [Uri.file(this.resourcesPath).with({scheme: 'vscode-resource'})]
+            localResourceRoots: [Uri.parse(this.resourcesPath).with({scheme: 'vscode-resource'})]
         };
 
         this.panel = window.createWebviewPanel(this.type, this.title, ViewColumn.Two,
@@ -96,7 +96,7 @@ export class CustomView extends EventEmitter implements Disposable {
     }
 
     private replaceUris(html: string, htmlPath: string) {
-        let basePath = Uri.file(dirname(htmlPath)).with({scheme: this.resourceScheme}).toString();
+        let basePath = Uri.parse(dirname(htmlPath)).with({scheme: this.resourceScheme}).toString();
         let regex = /(href|src)\=\"(.+?)\"/g;
         html = html.replace(regex, `$1="${basePath+'$2'}"`);
         return html;

--- a/src/resultview/customview.ts
+++ b/src/resultview/customview.ts
@@ -62,7 +62,7 @@ export class CustomView extends EventEmitter implements Disposable {
         let options = {
             enableScripts: true,
             retainContextWhenHidden: false, // we dont need to keep the state
-            localResourceRoots: [Uri.parse(this.resourcesPath).with({scheme: 'vscode-resource'})]
+            localResourceRoots: [Uri.file(this.resourcesPath).with({scheme: 'vscode-resource'})]
         };
 
         this.panel = window.createWebviewPanel(this.type, this.title, ViewColumn.Two,
@@ -96,7 +96,7 @@ export class CustomView extends EventEmitter implements Disposable {
     }
 
     private replaceUris(html: string, htmlPath: string) {
-        let basePath = Uri.parse(dirname(htmlPath)).with({scheme: this.resourceScheme}).toString();
+        let basePath = Uri.file(dirname(htmlPath)).with({scheme: this.resourceScheme}).toString();
         let regex = /(href|src)\=\"(.+?)\"/g;
         html = html.replace(regex, `$1="${basePath+'$2'}"`);
         return html;

--- a/src/sqlite/sqlite.ts
+++ b/src/sqlite/sqlite.ts
@@ -9,15 +9,17 @@ export function execute(sqliteCommand: string, dbPath: string, query: string, ca
     let streamParser = new StreamParser(new ResultSetParser());
 
     let args = [
-        `${dbPath}`, `${query}`,
+        `${dbPath}`,
         `-header`, // print the headers before the result rows
         `-nullvalue`, `NULL`, // print NULL for null values
         `-echo`, // print the statement before the result
         `-cmd`, `.mode tcl`
         ];
 
-    let proc = child_process.spawn(sqliteCommand, args, {stdio: ['ignore', "pipe", "pipe" ]});
+    let proc = child_process.spawn(sqliteCommand, args, {stdio: ['pipe', "pipe", "pipe" ]});
 
+    proc.stdin.end(query);
+    
     proc.stdout.pipe(streamParser).once('done', (data: ResultSet) => {
         resultSet = data;
     });


### PR DESCRIPTION
This patch solves the issue that queries including Unicode characters not passed to sqlite3 correctly in Windows environment.

Before:
![before](https://user-images.githubusercontent.com/1079715/51698448-9112a680-204d-11e9-8ea8-38994cbba09d.PNG)

After:
![after](https://user-images.githubusercontent.com/1079715/51698442-8d7f1f80-204d-11e9-87b4-78a4ecd2b8a2.PNG)
