### PR TITLE
Use Uri.file instead of Uri.parse

### DIFF
--- a/src/resultview/customview.ts
+++ b/src/resultview/customview.ts
@@ -62,7 +62,7 @@ export class CustomView extends EventEmitter implements Disposable {
         let options = {
             enableScripts: true,
             retainContextWhenHidden: true,
-            localResourceRoots: [Uri.parse(this.resourcesPath).with({scheme: this.resourceScheme})]
+            localResourceRoots: [Uri.file(this.resourcesPath).with({scheme: this.resourceScheme})]
         };
 
         this.panel = window.createWebviewPanel(this.type, this.title, ViewColumn.Two,
@@ -96,7 +96,7 @@ export class CustomView extends EventEmitter implements Disposable {
     }
 
     private replaceUris(html: string, htmlPath: string) {
-        let basePath = Uri.parse(dirname(htmlPath)).with({scheme: this.resourceScheme}).toString();
+        let basePath = Uri.file(dirname(htmlPath)).with({scheme: this.resourceScheme}).toString();
         let regex = /(href|src)\=\"(.+?)\"/g;
         html = html.replace(regex, `$1="${basePath+'$2'}"`);
         return html;


### PR DESCRIPTION
An Windows filepath includes a drive letter, parsed as scheme, lacked from generated uri.
Using Uri.file make the extension work correctly even the dev repository is in D: drive.

Fix #51

Before:
`vscode-resource:%5Cmande%5Cdev%5Cvscode-sqlite%5Cout%5Cresultview%5Chtmlcontent%5Cbundle.a2ba7.js`

![002](https://user-images.githubusercontent.com/1079715/51758481-24f57880-2109-11e9-97cc-e0da3c044c27.PNG)

After:
`vscode-resource:/d%3A/mande/dev/vscode-sqlite/out/resultview/htmlcontent/bundle.a2ba7.js`
![003](https://user-images.githubusercontent.com/1079715/51758483-2626a580-2109-11e9-9405-6f13678ab899.PNG)
