### PR TITLE
Fix #97, #99

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -281,8 +281,11 @@ function explorerRefresh(): Thenable<any> {
     );
 }
 
-function newQuerySelect(table: Schema.Table): Thenable<any> {
-    let contentL0 = `SELECT ${table.columns.map(c => c.name).join(", ")}`;
+export function newQuerySelect(table: Schema.Table): Thenable<any> {
+    function sqlSafeColName(name: string) {
+        return name.indexOf(" ") < 0 ? name : `\`${name}\``;
+    }
+    let contentL0 = `SELECT ${table.columns.map(c => sqlSafeColName(c.name)).join(", ")}`;
     let contentL1 = `FROM \`${table.name}\`;`;
     let content = contentL0 + "\n" + contentL1;
     let cursorPos = new Position(1, contentL1.length-1);
@@ -290,7 +293,10 @@ function newQuerySelect(table: Schema.Table): Thenable<any> {
 }
 
 function newQueryInsert(table: Schema.Table): Thenable<any> {
-    let contentL0 = `INSERT INTO \`${table.name}\` (${table.columns.map(c => c.name).join(", ")})`;
+    function sqlSafeColName(name: string) {
+        return name.indexOf(" ") < 0 ? name : `\`${name}\``;
+    }
+    let contentL0 = `INSERT INTO \`${table.name}\` (${table.columns.map(c => sqlSafeColName(c.name)).join(", ")})`;
     let contentL1 = `VALUES ();`;
     let content = contentL0 + "\n" + contentL1;
     // move the cursor inside the round brackets

--- a/src/sqlite/schema.ts
+++ b/src/sqlite/schema.ts
@@ -1,7 +1,6 @@
 import { CliDatabase } from "./cliDatabase";
 import { isFileSync } from "../utils/files";
 import { logger } from "../logging/logger";
-import { showErrorMessage } from "../vscodewrapper";
 
 export type Schema = Schema.Database;
 

--- a/src/sqlite/schema.ts
+++ b/src/sqlite/schema.ts
@@ -1,5 +1,7 @@
 import { CliDatabase } from "./cliDatabase";
 import { isFileSync } from "../utils/files";
+import { logger } from "../logging/logger";
+import { showErrorMessage } from "../vscodewrapper";
 
 export type Schema = Schema.Database;
 
@@ -59,7 +61,11 @@ export namespace Schema {
                 for(let table of schema.tables) {
                     let columnQuery = `PRAGMA table_info('${table.name}');`;
                     database.execute(columnQuery, (rows, err) => {
-                        if (err) return reject(err);
+                        if (err) {
+                            const msg = `Error retrieving '${table.name}' schema: ${err}`;
+                            logger.warn(msg);
+                            return;
+                        }
 
                         if (rows.length < 2) return;
 


### PR DESCRIPTION
#97: Columns with spaces in the name are now wrapped using the back quote `` ` ``
#99: Errors retrieving a table/view schema are now only logged as warning