### PR TITLE
Add command for drop & create query in explorer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
                 "category": "SQLite"
             },
             {
+                "command": "sqlite.newQueryCreate",
+                "title": "New Query [Drop & Create]",
+                "category": "SQLite"
+            },
+            {
                 "command": "sqlite.quickQuery",
                 "title": "Quick Query",
                 "category": "SQLite"
@@ -224,6 +229,11 @@
                     "command": "sqlite.newQueryInsert",
                     "group": "sqlite",
                     "when": "false"
+                },
+                {
+                    "command": "sqlite.newQueryCreate",
+                    "group": "sqlite",
+                    "when": "false"
                 }
             ],
             "explorer/context": [
@@ -315,6 +325,11 @@
                 },
                 {
                     "command": "sqlite.newQueryInsert",
+                    "when": "view == sqlite.explorer && viewItem == sqlite.tableItem",
+                    "group": "2_sql@2"
+                },
+                {
+                    "command": "sqlite.newQueryCreate",
                     "when": "view == sqlite.explorer && viewItem == sqlite.tableItem",
                     "group": "2_sql@2"
                 },

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -14,6 +14,7 @@ export namespace Schema {
         name: string;
         type: string;
         columns: Schema.Column[];
+        sql: string;
     }
 
     export interface Column {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ export namespace Commands {
     export const newQuery: string = 'sqlite.newQuery';
     export const newQuerySelect: string = 'sqlite.newQuerySelect';
     export const newQueryInsert: string = 'sqlite.newQueryInsert';
+    export const newQueryCreate: string = 'sqlite.newQueryCreate';
     export const quickQuery: string = 'sqlite.quickQuery';
     export const runTableQuery: string = 'sqlite.runTableQuery';
     export const runSqliteMasterQuery: string = 'sqlite.runSqliteMasterQuery';
@@ -130,6 +131,10 @@ export function activate(context: ExtensionContext): Promise<boolean> {
     
     context.subscriptions.push(commands.registerCommand(Commands.newQueryInsert, (table: Schema.Table) => {
         return newQueryInsert(table);
+    }));
+    
+    context.subscriptions.push(commands.registerCommand(Commands.newQueryCreate, (table: Schema.Table) => {
+        return newQueryCreate(table);
     }));
     
     context.subscriptions.push(commands.registerCommand(Commands.quickQuery, () => {
@@ -306,6 +311,13 @@ function newQueryInsert(table: Schema.Table): Thenable<any> {
     let content = contentL0 + "\n" + contentL1;
     // move the cursor inside the round brackets
     let cursorPos = new Position(1, contentL1.length-2);
+    return newQuery(table.database, content, cursorPos);
+}
+
+function newQueryCreate(table: Schema.Table): Thenable<any> {
+    let contentL0 = `DROP ${table.type.toUpperCase()} IF EXISTS ${sqlSafeName(table.name)};`;
+    let content = contentL0 + "\n" + table.sql + ";";
+    let cursorPos = new Position(0, 0);
     return newQuery(table.database, content, cursorPos);
 }
 

--- a/src/sqlite/schema.ts
+++ b/src/sqlite/schema.ts
@@ -18,6 +18,7 @@ export namespace Schema {
         name: string;
         type: string;
         columns: Schema.Column[];
+        sql: string;
     }
 
     export interface Column extends Schema.Item {
@@ -39,7 +40,7 @@ export namespace Schema {
                 tables: []
             } as Schema.Database;
 
-            const tablesQuery = `SELECT name, type FROM sqlite_master
+            const tablesQuery = `SELECT name, type, sql FROM sqlite_master
                                 WHERE (type="table" OR type="view")
                                 AND name <> 'sqlite_sequence'
                                 AND name <> 'sqlite_stat1'
@@ -54,7 +55,7 @@ export namespace Schema {
 
                 rows.shift(); // remove header from rows
                 schema.tables = rows.map(row => {
-                    return {database: dbPath, name: row[0], type: row[1], columns: [] } as Schema.Table;
+                    return {database: dbPath, name: row[0], type: row[1], columns: [], sql: row[2] } as Schema.Table;
                 });
 
                 for(let table of schema.tables) {


### PR DESCRIPTION
CHANGES:

- Saves the table/view definition when the database is loaded. 
- Added a command to explorer items menus to generate a query with "DROP" statement followed by the original "CREATE" statement  saved when the database is loaded.
