### PR TITLE
Support generated columns

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,31 +1,4 @@
-export type Schema = Schema.Database;
-
-export namespace Schema {
-
-    export type Item = Database | Table | Column;
-
-    export interface Database {
-        path: string;
-        tables: Schema.Table[];
-    }
-
-    export interface Table {
-        database: string;
-        name: string;
-        type: string;
-        columns: Schema.Column[];
-    }
-
-    export interface Column {
-        database: string;
-        table: string;
-        name: string;
-        type: string;
-        notnull: boolean;
-        pk: number;
-        defVal: string;
-    }
-}
+export { Schema } from '../sqlite/schema';
 
 export type ResultSet = Array<Result>;
 

--- a/src/explorer/explorerTreeProvider.ts
+++ b/src/explorer/explorerTreeProvider.ts
@@ -44,13 +44,13 @@ export class ExplorerTreeProvider implements TreeDataProvider<Schema.Item> {
     getTreeItem(item: Schema.Item): TreeItem {
         if ('tables' in item) {
             // Database
-            return new DBItem(this.context, item.path);
+            return new DBItem(this.context, item);
         } else if ('columns' in item) {
             // Table
-            return new TableItem(this.context, item.name, item.type);
+            return new TableItem(this.context, item);
         } else {
             // Column
-            return new ColumnItem(this.context, item.name, item.type, item.notnull, item.pk, item.defVal);
+            return new ColumnItem(this.context, item);
         }
     }
 

--- a/src/sqlDocumentCommandsHandler.ts
+++ b/src/sqlDocumentCommandsHandler.ts
@@ -88,9 +88,10 @@ export class SqlDocumentCommandsHandler
     }
 
     private async onNewQueryInsert(table: Schema.Table): Promise<Uri> {
+        const columnsNotGenerated = table.columns.filter((c) => !c.generatedAlways);
         let contentL0 = `INSERT INTO ${sqlSafeName(
             table.name
-        )} (${table.columns.map((c) => sqlSafeName(c.name)).join(", ")})`;
+        )} (${columnsNotGenerated.map((c) => sqlSafeName(c.name)).join(", ")})`;
         let contentL1 = `VALUES ();`;
         let content = contentL0 + "\n" + contentL1;
         // move the cursor inside the round brackets

--- a/src/sqlite/cliDatabase.ts
+++ b/src/sqlite/cliDatabase.ts
@@ -125,6 +125,15 @@ export class CliDatabase implements Database {
         }
     }
 
+    executePromise(sql: string): Promise<string[][]> {
+        return new Promise((resolve, reject) => {
+            this.execute(sql, (rows, err) => {
+                if (err) reject(err);
+                else resolve(rows);
+            })
+        })
+    }
+
     private _write(text: string) {
         if (!this.sqliteProcess) return;
         


### PR DESCRIPTION
List generated columns with table_xinfo pragma.
The table_xinfo pragma first appeared in SQLite 3.26.0. If current sqlite doesn't support table_xinfo, table_info is used as fallback method.
Generated columns first appeared in SQLite 3.31.0.

Fix https://github.com/AlexCovizzi/vscode-sqlite/issues/192