### PR TITLE
Update schema syntax for sqlite 3.4.1

### DIFF
--- a/src/sqlite/schema.ts
+++ b/src/sqlite/schema.ts
@@ -44,7 +44,7 @@ export namespace Schema {
             } as Schema.Database;
 
             const tablesQuery = `SELECT name, type FROM sqlite_master
-                                WHERE (type="table" OR type="view")
+                                WHERE (type='table' OR type='view')
                                 AND name <> 'sqlite_sequence'
                                 AND name <> 'sqlite_stat1'
                                 ORDER BY type ASC, name ASC;`;


### PR DESCRIPTION
Extension doesn't work with newest version of sqlite3, updated syntax.
See issue https://github.com/AlexCovizzi/vscode-sqlite/issues/235